### PR TITLE
fix pause problem in ie

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Build (Pack and optimize js, reivision js and add entry in `index.html`):
 gulp build
 ```
 
+### Special notice
+However there is a significant anomaly here in Opera, Safari and IE10, which is that the .paused flag remains false when the media has ended.
+You can see the problem [here](here)
+
+Fixed by firing the pause() method and setting currentTime at 0 manually, in response to the "ended" event
+[here]:http://www.sitepoint.com/essential-audio-and-video-events-for-html5/
+
 ### License
 
 MIT

--- a/src/audio.coffee
+++ b/src/audio.coffee
@@ -65,6 +65,10 @@ module.exports = React.createClass
 
   endPlay: ->
     @setState pause: true, playPercent: 0
+    # ".paused" flag remains false in Opera, Safari and IE10, when the audio has ended.
+    # firing the pause() method manually in response to the "ended" event
+    @_audioEl.pause()
+    @_audioEl.currentTime = 0
 
   playClick: ->
     if @_audioEl.paused

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -11,7 +11,7 @@ App = React.createClass
   displayName: 'page-app'
 
   render: ->
-    source = 'http://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3'
+    source = 'http://www.alexkatz.me/codepen/music/interlude.mp3'
     LiteAudio source: source, isUnread: true
 
 PageApp = React.createFactory App


### PR DESCRIPTION
There is a significant anomaly here in Opera, Safari and IE10, which is that the ".paused" flag remains false when the media has ended. 
Fixed by firing the pause() method and setting currentTime at 0 manually, in response to the "ended" event
